### PR TITLE
feat: add getKeys method and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is a wrapper for the Chrome Extension Storage API that adds
 - [API](#api)
   - [interface Bucket](#api-bucket)
     - [bucket.get()](#api-bucket-get)
+    - [bucket.getKeys()](#api-bucket-getKeys)
     - [bucket.set()](#api-bucket-set)
     - [bucket.remove()](#api-bucket-remove)
     - [bucket.clear()](#api-bucket-clear)
@@ -257,6 +258,19 @@ getter.
 bucket.get('a') // resolves to object as key/value pair
 bucket.get({ a: 123 }) // same, but 123 is default value
 bucket.get(({ a }) => a) // resolves to value of "a"
+```
+
+## async function `bucket.getKeys` <a name = "api-bucket-getKeys"></a>
+
+Takes an optional getter. Resolves to an array of strings that represents the keys of the values in the storage area bucket.
+
+```typescript
+function getKeys() => Promise<string[]>
+```
+
+```typescript
+bucket.set({ a: 123 })
+bucket.getKeys() // Resolves to ['a']
 ```
 
 ## async function `bucket.set` <a name = "api-bucket-set"></a>

--- a/src/bucket/index.ts
+++ b/src/bucket/index.ts
@@ -1,8 +1,3 @@
-import chromep from 'chrome-promise'
-import { chromepApi } from 'chrome-promise/chrome-promise'
-import { concat, from, fromEventPattern } from 'rxjs'
-import { filter, map, mergeMap } from 'rxjs/operators'
-import { isNonNull } from '../guards'
 import {
   AreaName,
   Bucket,
@@ -10,7 +5,13 @@ import {
   CoreGetter,
   Getter,
 } from '../types'
+import { concat, from, fromEventPattern } from 'rxjs'
+import { filter, map, mergeMap } from 'rxjs/operators'
+
+import chromep from 'chrome-promise'
+import { chromepApi } from 'chrome-promise/chrome-promise'
 import { invalidSetterReturn } from '../validate'
+import { isNonNull } from '../guards'
 
 export { Bucket }
 
@@ -288,6 +289,10 @@ export function getBucket<T extends Record<string, any>>(
       const store = await get()
       const result = await updater(store)
       return set(result)
+    },
+
+    async getKeys() {
+      return getKeys()
     },
 
     get changeStream() {

--- a/src/jest/jest-mock.test.ts
+++ b/src/jest/jest-mock.test.ts
@@ -1,6 +1,7 @@
-import { Subject } from 'rxjs'
 import { getBucket, storage } from './jest-mock'
+
 import { MockBucket } from './jest-mock'
+import { Subject } from 'rxjs'
 
 jest.mock('../index.ts')
 
@@ -17,6 +18,7 @@ test('storage.local is mocked', async () => {
     update: expect.any(MockInstance),
     remove: expect.any(MockInstance),
     clear: expect.any(MockInstance),
+    getKeys: expect.any(MockInstance),
     changeStream: expect.any(Subject),
     valueStream: expect.any(Subject),
   })
@@ -42,12 +44,13 @@ test('getBucket returns MockBucket', async () => {
     update: expect.any(MockInstance),
     remove: expect.any(MockInstance),
     clear: expect.any(MockInstance),
+    getKeys: expect.any(MockInstance),
     changeStream: expect.any(Subject),
     valueStream: expect.any(Subject),
   })
 
   const defaultValue = { a: 'a', b: 1 }
-  
+
   mockStorageArea.get.mockImplementation(async () => {
     return defaultValue
   })

--- a/src/jest/jest-mock.ts
+++ b/src/jest/jest-mock.ts
@@ -1,6 +1,7 @@
+import { Bucket, Changes } from '..'
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Subject } from 'rxjs'
-import { Bucket, Changes } from '..'
 
 /**
  * This module is a pre-mocked version of storage for use with Jest.
@@ -37,6 +38,7 @@ export const getBucket = <T extends object>(
   update: jest.fn(),
   remove: jest.fn(),
   clear: jest.fn(),
+  getKeys: jest.fn(),
   changeStream: new Subject<Changes<T>>(),
   valueStream: new Subject<T>(),
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,8 @@ export interface Bucket<T extends object> {
   remove: (query: string | string[]) => Promise<void>
   /** Clear the storage area */
   clear: () => Promise<void>
+  /** Get the keys (or property names) of the storage area */
+  getKeys: () => Promise<string[]>
   /** Emits an object with changed storage keys and StorageChange values  */
   readonly changeStream: Observable<Changes<T>>
   /** Emits the current storage values immediately and when changeStream emits */


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #15 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

It's useful to be able to retrieve the keys that a storage bucket is using.

#### Usage

```javascript
const keys = await bucket.getKeys()

console.log(keys) // array of key names that are stored in the bucket
```