### PR TITLE
Load global storage object in a lazy manner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,21 @@
-import { getBucket } from './bucket'
+import { Bucket, getBucket } from './bucket'
+
+type Storage = {
+  local: Bucket<Record<string, any>>,
+  sync: Bucket<Record<string, any>>,
+  managed: Bucket<Record<string, any>>,
+}
+
+class StorageImpl implements Storage {
+  get local(): Bucket<Record<string, any>> { return getBucket<Record<string, any>>('local', 'local') }
+  get sync(): Bucket<Record<string, any>> { return getBucket<Record<string, any>>('sync', 'sync') }
+  get managed(): Bucket<Record<string, any>> { return getBucket<Record<string, any>>('managed', 'managed') }
+}
 
 /**
  * Buckets for each storage area.
  */
-export const storage = {
-  local: getBucket<Record<string, any>>('local', 'local'),
-  sync: getBucket<Record<string, any>>('sync', 'sync'),
-  managed: getBucket<Record<string, any>>('managed', 'managed'),
-}
+export const storage: Storage = new StorageImpl()
 
 // Workaround for @rollup/plugin-typescript
 export * from './types'


### PR DESCRIPTION
<!--
  We ❤️ Pull Requests!

  Thanks for putting in the work to contribute to this project.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please run prettier and eslint.
  * Please update the documentation where necessary.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Community guidelines:

- [x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

The global `storage` object is loaded eagerly, as a result it's evaluated as a side effect whenever the package is loaded, even when just pure functions (e.g. `getBucket`) are imported/used. It is quite unexpected from user's perspective and makes testing troublesome (e,g. testing the UI part of an extension in non extension environment always fails simply because `@extend-chrome/storage` is loaded to the bundle)

P.S. There's no system test setup in the repo to test these sort of problems, hence no extra tests added.    

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
